### PR TITLE
Update package.json

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-cognito-identitypool-alpha": "^2.31.1-alpha.0",
-    "aws-cdk-lib": "2.31.1",
+    "aws-cdk-lib": "^2.38",
     "cdk-nag": "^2.20.3",
     "constructs": "^10.1.152",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
Today, this is pulling in an older version of NodeJS14 which is no longer supported.  So, when you go to deploy solution CDK will error out when trying to spin up auto generated lambda's with DynamoDB cross-region support.  By changing this version you will now be generating lambda's using NodeJS20

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
